### PR TITLE
ported makefile to MacOS and removed commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,18 +26,15 @@ LDLIBS = -lcurses -lm
 all: game
 
 # this project contains multiple C files, which are dependent on header files that we find using makedepend, so header files  are not listed here
-SRCS := $(shell find -name "*.c" -not -path "./tests/*" -not -path "./game.c")
+SRCS := $(shell find . -name "*.c" -not -path "./tests/*" -not -path "./game.c")
 OBJS := $(patsubst %.c,$(BUILDDIR)/%.o,$(SRCS))
-$(shell mkdir -p `dirname $(SRCS) | sed -e 's/^/$(DEPDIR)\//'`)
-$(shell mkdir -p `dirname $(SRCS) | sed -e 's/^/$(BUILDDIR)\//'`)
-
 
 print-%  : ; @echo $* = $($*)
 
-
-
 $(BUILDDIR)/%.o : %.c
 $(BUILDDIR)/%.o : %.c $(DEPDIR)/%*.d
+	mkdir -p $(DEPDIR)/$(shell dirname $<)
+	mkdir -p $(BUILDDIR)/$(shell dirname $<)
 	$(COMPILE.c) $(OUTPUT_OPTION) $<
 	$(POSTCOMPILE)
 


### PR DESCRIPTION
having inline commands that do stuff when you read a Makefile is evil
customer running makefile in dry run mode would expect no changes to
happen.  inline script has been replaced with additional actions on
those targets that need them